### PR TITLE
Bump Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,14 +21,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.9.0</maven.compiler.plugin.version>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.3.0</maven.javadoc.plugin.version>
         <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-        <jackson-databind.version>2.12.5</jackson-databind.version>
-        <aerospike-client.version>5.1.7</aerospike-client.version>
-        <junit-jupiter.version>5.7.2</junit-jupiter.version>
+        <jackson-databind.version>2.13.1</jackson-databind.version>
+        <aerospike-client.version>5.1.11</aerospike-client.version>
+        <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <json-path.version>2.6.0</json-path.version>
     </properties>
 


### PR DESCRIPTION
Bump Dependencies:
maven-compiler-plugin from 3.8.1 to 3.9.0.
jackson-databind from 2.12.5 to 2.13.1.
aerospike-client from 5.1.7 to 5.1.11.
junit-jupiter from 5.7.2 to 5.8.2.