### PR TITLE
Prepare version 1.2.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.aerospike</groupId>
     <artifactId>aerospike-document-api</artifactId>
-    <version>1.1.3</version>
+    <version>1.2.0</version>
 
     <name>Aerospike Document API</name>
     <description>This project provides an API which allows Aerospike CDT (Collection Data Type) objects to be accessed and mutated using JSON like syntax.
@@ -21,15 +21,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.plugin.version>3.9.0</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
-        <maven.javadoc.plugin.version>3.3.0</maven.javadoc.plugin.version>
+        <maven.javadoc.plugin.version>3.4.1</maven.javadoc.plugin.version>
         <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
-        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-        <jackson-databind.version>2.13.1</jackson-databind.version>
-        <aerospike-client.version>5.1.11</aerospike-client.version>
-        <junit-jupiter.version>5.8.2</junit-jupiter.version>
-        <json-path.version>2.6.0</json-path.version>
+        <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
+        <jackson-databind.version>2.13.3</jackson-databind.version>
+        <aerospike-client.version>6.1.1</aerospike-client.version>
+        <junit-jupiter.version>5.9.0</junit-jupiter.version>
+        <json-path.version>2.7.0</json-path.version>
     </properties>
 
     <licenses>

--- a/src/test/java/com/aerospike/documentapi/JsonPathQueryTests/JsonPathMultipleBinsTests.java
+++ b/src/test/java/com/aerospike/documentapi/JsonPathQueryTests/JsonPathMultipleBinsTests.java
@@ -63,22 +63,6 @@ public class JsonPathMultipleBinsTests extends BaseTestConfig {
         expectedObjectsCombined.put(documentBinName2, expectedObject2);
         assertTrue(TestJsonConverters.jsonEquals(objectFromDB, expectedObjectsCombined));
 
-        jsonPath = "$.authentication..user";
-
-        // Delete the user field from all of the authentications (login and logout)
-        documentClient.delete(TEST_AEROSPIKE_KEY, bins, jsonPath);
-        objectFromDB = documentClient.get(TEST_AEROSPIKE_KEY, bins, jsonPath);
-
-        modifiedJson1 = JsonPath.parse(events1).delete(jsonPath).json();
-        expectedObject1 = JsonPath.read(modifiedJson1, jsonPath);
-        modifiedJson2 = JsonPath.parse(events2).delete(jsonPath).json();
-        expectedObject2 = JsonPath.read(modifiedJson2, jsonPath);
-
-        expectedObjectsCombined.clear();
-        expectedObjectsCombined.put(documentBinName1, expectedObject1);
-        expectedObjectsCombined.put(documentBinName2, expectedObject2);
-        assertTrue(TestJsonConverters.jsonEquals(objectFromDB, expectedObjectsCombined));
-
         jsonPath = "$.authentication.login[?(@.id > 10)]";
 
         client.delete(null, TEST_AEROSPIKE_KEY);


### PR DESCRIPTION
1. Set version to 1.2.0.
2. Remove a redundant (and wrong) test case.
3. Bump dependencies.